### PR TITLE
(version-bump) chrome78 node12.13.1 yarn1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - 
 
 # Install Chrome
 # https://www.ubuntuupdates.org/ppa/google_chrome?dist=stable
-ENV CHROME_VERSION=74.0.3729.131-1
+ENV CHROME_VERSION=78.0.3904.97-1
 
 RUN apt-get update && apt-get install -y \
     google-chrome-stable=$CHROME_VERSION \
@@ -40,16 +40,16 @@ RUN curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 
 # Install yarn
 # https://www.ubuntuupdates.org/ppa/yarn?dist=stable
-ENV YARN_VERSION=1.15.2-1
+ENV YARN_VERSION=1.19.1-1
 
 RUN apt-get update && apt-get install -y \
     yarn=$YARN_VERSION \
     --no-install-recommends
 
-# Find your desired version here: https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/
+# Find your desired version here: https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/
 # Ubuntu 16.04.3 LTS (Xenial Xerus) (https://wiki.ubuntu.com/Releases)
-ENV NODE_VERSION=10.15.3
+ENV NODE_VERSION=12.13.0
 
-RUN curl https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/nodejs_$NODE_VERSION-1nodesource1_amd64.deb > node.deb \
+RUN curl https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_$NODE_VERSION-1nodesource1_amd64.deb > node.deb \
  && dpkg -i node.deb \
  && rm node.deb

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ This Docker image is maintained by WeltN24 GmbH Developers and its main purpose 
 - Login to Docker Hub is done via personalized accounts, which have to be connected to [r/springmedia](https://hub.docker.com/u/springmedia/)
 
 ## How to install a specific version of node?
-1. Find your desired version here: [https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/](https://deb.nodesource.com/node_10.x/pool/main/n/nodejs/)
+1. Find your desired version here: [https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/](https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/)
 1. Replace .deb url in Dockerfile
 
 ## Changelog
+- **2019-11-18**: `Chrome 78`, `node 12.13.0`, `yarn 1.19.1`
 - **2019-05-08**: `Chrome 74`, `node 10.15.3`, `yarn 1.15.2`
 - **2018-10-01**: `Chrome 69`, `node 10.9`, `yarn 1.10.1`
 - **2018-06-28**: `Chrome 67`, `node 10.5`, `yarn 1.7.0`


### PR DESCRIPTION
- `Chrome 78`
- `node 12.13.0`
- `yarn 1.19.1`